### PR TITLE
Rename client.Scope -> client.Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ client, err := codeship.New("username", "password")
 You must then scope the client to a single Organization that you have access to:
 
 ```go
-org, err := client.Scope(ctx, "codeship")
+org, err := client.Organization(ctx, "codeship")
 ```
 
 You can then perform calls to the API on behalf of an Organization:

--- a/authentication_test.go
+++ b/authentication_test.go
@@ -116,7 +116,7 @@ func TestAuthenticate(t *testing.T) {
 			mux.HandleFunc("/auth", tt.handler)
 
 			client, _ = codeship.New("username", "password", codeship.BaseURL(server.URL))
-			org, _ = client.Scope(context.Background(), "codeship")
+			org, _ = client.Organization(context.Background(), "codeship")
 
 			defer func() {
 				server.Close()

--- a/codeship.go
+++ b/codeship.go
@@ -142,8 +142,8 @@ func New(username, password string, opts ...Option) (*Client, error) {
 	return client, nil
 }
 
-// Scope scopes a client to a single Organization, allowing the user to make calls to the API
-func (c *Client) Scope(ctx context.Context, name string) (*Organization, error) {
+// Organization scopes a client to a single Organization, allowing the user to make calls to the API
+func (c *Client) Organization(ctx context.Context, name string) (*Organization, error) {
 	if c.AuthenticationRequired() {
 		if _, err := c.Authenticate(ctx); err != nil {
 			return nil, err

--- a/codeship_test.go
+++ b/codeship_test.go
@@ -41,7 +41,7 @@ func setup() func() {
 	})
 
 	client, _ = codeship.New("test", "pass", codeship.BaseURL(server.URL))
-	org, _ = client.Scope(context.Background(), "codeship")
+	org, _ = client.Organization(context.Background(), "codeship")
 
 	return func() {
 		server.Close()
@@ -262,7 +262,7 @@ func TestScope(t *testing.T) {
 			mux.HandleFunc("/auth", tt.handler)
 
 			c, _ := codeship.New("username", "password", codeship.BaseURL(server.URL))
-			got, err := c.Scope(context.Background(), tt.args.name)
+			got, err := c.Organization(context.Background(), tt.args.name)
 
 			if tt.err != nil {
 				require.Error(err)
@@ -307,7 +307,7 @@ func TestVerboseLogger(t *testing.T) {
 		codeship.Logger(logger),
 	)
 
-	org, err = c.Scope(context.Background(), "codeship")
+	org, err = c.Organization(context.Background(), "codeship")
 
 	assert := assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
After talking with @brett and @georgemac, we think it makes more sense to rename `Scope` to `Organization`
from a UX standpoint.