### PR TITLE
Test with multiple go versions using x/build/version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM golang:1.9
+FROM golang:1.9 AS build
 LABEL maintainer=dev@codeship.com
+RUN go get -v github.com/alecthomas/gometalinter && \
+	go get -v golang.org/x/tools/cmd/cover
+RUN gometalinter --install
 
+FROM build
+LABEL maintainer=dev@codeship.com
 RUN mkdir -p /go/src/github.com/codeship/codeship-go
-
 ADD . /go/src/github.com/codeship/codeship-go/
 WORKDIR /go/src/github.com/codeship/codeship-go

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOPACKAGES := $(go list ./... | grep -v /vendor/)
 .PHONY: setup
 setup: ## Install all the build and lint dependencies
 	go get -u $(GOTOOLS)
-	gometalinter --install --update
+	gometalinter --install
 
 .PHONY: dep
 dep: ## Run dep ensure and prune

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -8,14 +8,8 @@ go1.9:
   encrypted_env_file: env.encrypted
   cached: true
 
-go1.8:
+gov:
   build:
     context: .
-    dockerfile: ./docker/go-1.8/Dockerfile
-  cached: true
-
-go1.10rc:
-  build:
-    context: .
-    dockerfile: ./docker/go-1.10rc/Dockerfile
+    dockerfile: ./docker/gov/Dockerfile
   cached: true

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,21 +1,21 @@
 - type: parallel
   steps:
+  - service: gov
+    name: "1.8.6 test"
+    command: gov 1.8.6 test -v
+
+  - service: gov
+    name: "1.10rc1 test"
+    command: gov 1.10rc1 test -v
+
+- type: parallel
+  steps:
   - service: go1.9
     name: "lint"
-    command: make setup lint
+    command: make lint
   - service: go1.9
-    name: "1.9 test"
-    command: make test
-  - service: go1.8
-    name: "1.8 test"
-    command: make test
-  - service: go1.10rc
-    name: "1.10rc test"
-    command: make test
-
-- service: go1.9
-  name: coverage
-  command: ./scripts/cover
+    name: "coverage"
+    command: ./scripts/cover
 
 - service: integration
   name: "integration tests"

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,4 +1,5 @@
 - type: parallel
+  name: "multi-version tests"
   steps:
   - service: gov
     name: "1.8.6 test"
@@ -9,6 +10,7 @@
     command: gov 1.10rc1 test -v
 
 - type: parallel
+  name: "tests"
   steps:
   - service: go1.9
     name: "lint"

--- a/docker/go-1.10rc/Dockerfile
+++ b/docker/go-1.10rc/Dockerfile
@@ -1,7 +1,0 @@
-FROM golang:1.10-rc
-LABEL maintainer=dev@codeship.com
-
-RUN mkdir -p /go/src/github.com/codeship/codeship-go
-
-ADD . /go/src/github.com/codeship/codeship-go/
-WORKDIR /go/src/github.com/codeship/codeship-go

--- a/docker/go-1.8/Dockerfile
+++ b/docker/go-1.8/Dockerfile
@@ -1,7 +1,0 @@
-FROM golang:1.8
-LABEL maintainer=dev@codeship.com
-
-RUN mkdir -p /go/src/github.com/codeship/codeship-go
-
-ADD . /go/src/github.com/codeship/codeship-go/
-WORKDIR /go/src/github.com/codeship/codeship-go

--- a/docker/gov/Dockerfile
+++ b/docker/gov/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.9 AS build
+LABEL maintainer=dev@codeship.com
+RUN mkdir -p /go/src/github.com/codeship/gov
+ADD ./docker/gov /go/src/github.com/codeship/gov
+WORKDIR /go/src/github.com/codeship/gov
+RUN go get golang.org/x/build/version
+RUN go install
+
+# go 1.8.6
+RUN go get golang.org/x/build/version/go1.8.6 && \
+    go1.8.6 download
+
+# go 1.10.rc1
+RUN go get golang.org/x/build/version/go1.10rc1 && \
+    go1.10rc1 download
+
+FROM build
+LABEL maintainer=dev@codeship.com
+RUN mkdir -p /go/src/github.com/codeship/codeship-go
+ADD . /go/src/github.com/codeship/codeship-go/
+WORKDIR /go/src/github.com/codeship/codeship-go

--- a/docker/gov/gov.go
+++ b/docker/gov/gov.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/build/version"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Printf("USAGE: %v <version> [commands as normal]\n",
+			os.Args[0])
+		os.Exit(1)
+	}
+
+	v := os.Args[1]
+	os.Args = append(os.Args[0:1], os.Args[2:]...)
+
+	version.Run("go" + v)
+}

--- a/scripts/cover
+++ b/scripts/cover
@@ -2,5 +2,5 @@
 
 set -e
 
-go test -coverprofile=coverage.txt -covermode=atomic
+go test -v -coverprofile=coverage.txt -covermode=atomic
 curl -s https://codecov.io/bash | bash -s -


### PR DESCRIPTION
## Summary

From https://pocketgophers.com/trying-other-versions/

Using [x/build/version](https://godoc.org/golang.org/x/build/version#pkg-subdirectories) to test with multiple versions of go (1.8.6 and 1.10rc1 as of now) instead of using different Dockerfiles for each.

This uses a small [wrapper](https://github.com/codeship/codeship-go/blob/gov/docker/gov/gov.go) to run using the different versions

Ex: `gov 1.8.6 test -v` and `gov 1.10rc1 test -v` 

## Checklist

- [x] Added/updated tests?
- [x] Ran `make fmt`?
- [x] `make ci` passed?
- [ ] CHANGELOG.md [Unreleased] section updated?

