### PR TITLE
Use .gometalinter.json file for config

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,0 +1,24 @@
+{
+  "Enable": [
+    "deadcode",
+    "errcheck",
+    "goconst",
+    "gofmt",
+    "goimports",
+    "ineffassign",
+    "interfacer",
+    "maligned",
+    "megacheck",
+    "misspell",
+    "structcheck",
+    "testify",
+    "unparam",
+    "varcheck",
+    "vet"
+  ],
+  "Exclude": [
+    "vendor"
+  ],
+  "Deadline": "10m",
+  "WarnUnmatchedDirective": true
+}

--- a/Makefile
+++ b/Makefile
@@ -32,17 +32,7 @@ fmt: ## goimports all go files
 
 .PHONY: lint
 lint: ## Run all the linters
-	gometalinter --exclude=vendor --exclude=/go/src --disable-all \
-		--enable=deadcode \
-		--enable=ineffassign \
-		--enable=gofmt \
-		--enable=goimports \
-		--enable=misspell \
-		--enable=errcheck \
-		--enable=vet \
-		--enable=megacheck \
-		--deadline=10m \
-		$(GOPACKAGES)
+	gometalinter
 
 .PHONY: ci
 ci: lint ## Run all code checks and tests with coverage reporting


### PR DESCRIPTION
* Use .gometalinter.json file for config
* move pagination regex to global vars
* return response, no error if responseCode is `< 400`