### PR TITLE
Verify the tagged version is referenced in the CHANGELOG

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,8 @@
-.git/
 .gitignore
 .github/
 LICENSE
 
 *.txt
-*.md
 *.yml
 *.png
 *.jpg

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ GOTOOLS = \
 	github.com/golang/dep/cmd/dep \
 
 GOPACKAGES := $(go list ./... | grep -v /vendor/)
+VERSION ?= $(shell git describe --abbrev=0 --tags)
+CHANGELOG_VERSION = $(shell perl -ne '/^\#\# (\d+(\.\d+)+) / && print "$$1\n"' CHANGELOG.md | head -n1)
 
 .PHONY: setup
 setup: ## Install all the build and lint dependencies
@@ -45,6 +47,17 @@ build: ## Build a version
 .PHONY: clean
 clean: ## Remove temporary files
 	go clean
+
+.PHONY: verify
+verify: ## Verify the version is referenced in the CHANGELOG
+	@if [ "$(VERSION)" = "$(CHANGELOG_VERSION)" ]; then \
+		echo "version: $(VERSION)"; \
+	else \
+		echo "Version number not found in CHANGELOG.md"; \
+		echo "version: $(VERSION)"; \
+		echo "CHANGELOG: $(CHANGELOG_VERSION)"; \
+		exit 1; \
+	fi
 
 # Absolutely awesome: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 .PHONY: help

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,19 +1,24 @@
 - type: parallel
   name: "multi-version tests"
   steps:
-  - service: gov
-    name: "1.8.6 test"
+  - name: "1.8.6 test"
+    service: gov
     command: gov 1.8.6 test -v
 
-  - service: gov
-    name: "1.9.4 test"
+  - name: "1.9.4 test"
+    service: gov
     command: gov 1.9.4 test -v
 
 - name: "tests"
   service: test
   command: make ci
 
-- service: integration
-  name: "integration tests"
+- name: "integration tests"
+  service: integration
   tag: master
   command: make integration
+
+- name: "verify release"
+  service: test
+  tag: (\d+(\.\d+)+)
+  command: make verify


### PR DESCRIPTION
## Summary

Checks that the latest release (tagged version) is also referenced in the CHANGELOG.

Stolen from [glide](https://github.com/Masterminds/glide/blob/master/Makefile)

This will run in CI whenever we push a new tag.

✅:
```
$ make verify
version: 0.2.2
```

❌:
```
$ make verify
Version number not found in CHANGELOG.md
version: 0.2.2
CHANGELOG: 0.2.1
make: *** [verify] Error 1
```
