### PR TITLE
Replace codecov with coveralls

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,6 @@ Tell us in a few words or lines what this PR is about.
 
 - [ ] Added/updated tests?
 - [ ] Ran `make fmt`?
-- [ ] `make ci` passed?
 - [ ] CHANGELOG.md [Unreleased] section updated?
 
 ## Why was it changed?

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
 GOTOOLS = \
 	golang.org/x/tools/cmd/cover \
 	github.com/golangci/golangci-lint/cmd/golangci-lint@de1d1ad \
+	github.com/mattn/goveralls \
 
 GOPACKAGES := $(go list ./... | grep -v /vendor/)
-VERSION ?= $(shell git describe --abbrev=0 --tags)
-CHANGELOG_VERSION = $(shell perl -ne '/^\#\# (\d+(\.\d+)+) / && print "$$1\n"' CHANGELOG.md | head -n1)
 
 export GOBIN:=$(PWD)/bin
 export PATH:=$(GOBIN):$(PATH)
@@ -36,29 +35,6 @@ fmt: ## goimports all go files
 .PHONY: lint
 lint: ## Run all the linters
 	golangci-lint run
-
-.PHONY: ci
-ci: lint ## Run all code checks and tests with coverage reporting
-	./scripts/cover
-
-.PHONY: build
-build: ## Build a version
-	CGO_ENABLED=0 go build $(GOPACKAGES)
-
-.PHONY: clean
-clean: ## Remove temporary files
-	go clean
-
-.PHONY: verify
-verify: ## Verify the version is referenced in the CHANGELOG
-	@if [ "$(VERSION)" = "$(CHANGELOG_VERSION)" ]; then \
-		echo "version: $(VERSION)"; \
-	else \
-		echo "Version number not found in CHANGELOG.md"; \
-		echo "version: $(VERSION)"; \
-		echo "CHANGELOG: $(CHANGELOG_VERSION)"; \
-		exit 1; \
-	fi
 
 # Absolutely awesome: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 .PHONY: help

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Codeship API v2 Client for Go
 
 [![Codeship Status](https://app.codeship.com/projects/c38f3280-792b-0135-21bb-4e0cf8ff365b/status?branch=master)](https://app.codeship.com/projects/244943)
-[![Codecov](https://codecov.io/gh/codeship/codeship-go/branch/master/graph/badge.svg)](https://codecov.io/gh/codeship/codeship-go)
+[![Coverage Status](https://coveralls.io/repos/github/codeship/codeship-go/badge.svg)](https://coveralls.io/github/codeship/codeship-go)
 [![Go Doc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](http://godoc.org/github.com/codeship/codeship-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/codeship/codeship-go?style=flat-square)](https://goreportcard.com/report/github.com/codeship/codeship-go)
 [![GitHub Release](https://img.shields.io/github/release/codeship/codeship-go.svg?style=flat-square)](https://github.com/codeship/codeship-go/releases)
@@ -179,8 +179,4 @@ integration                    Run integration tests
 cover                          Run all the tests and opens the coverage report
 fmt                            goimports all go files
 lint                           Run all the linters
-ci                             Run all code checks and tests with coverage reporting
-build                          Build a version
-clean                          Remove temporary files
-verify                         Verify the version is referenced in the CHANGELOG
 ```

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -4,8 +4,7 @@ integration:
 
 test:
   build: ./
-  encrypted_env_file: env.encrypted
-  command: ./scripts/cover
+  encrypted_env_file: test.env.encrypted
 
 gov:
   build:

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -8,14 +8,14 @@
     service: gov
     command: go1.10.5 test -v
 
-- name: "tests"
+- name: "test"
   service: test
-  command: make ci
+  command: ./scripts/ci
 
 - name: "integration tests"
   service: integration
   tag: master
-  command: make integration
+  command: ./scripts/integration
 
 - name: "verify release"
   service: test

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -20,4 +20,4 @@
 - name: "verify release"
   service: test
   tag: (\d+(\.\d+)+)
-  command: make verify
+  command: ./scripts/verify

--- a/env.encrypted
+++ b/env.encrypted
@@ -1,2 +1,0 @@
-codeship:v2
-rGi+1eowiO36ZNwxMfRYpPKJwmz6PcHVtR2BYtquCi9v2mWX4Oo8nMeDjxfHZQuQDbbM8AoMaCAi4650y7EBwogx0c1D8/JBrNJDJnqNaVDLcb0KLTNgg7x64WtY+s3hl9bh

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,7 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.7 h1:UvyT9uN+3r7yLEYSlJsbQGdsaB/a0DlgWP3pql6iwOc=
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/goveralls v0.0.2 h1:7eJB6EqsPhRVxvwEXGnqdO2sJI0PTsrWoTMXEk9/OQc=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+golangci-lint run
+
+if [ "$CI" = "true" ]; then
+  goveralls -service=codeship
+fi

--- a/scripts/cover
+++ b/scripts/cover
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -euxo pipefail
-
-go test -v -coverprofile=coverage.txt -covermode=atomic
-
-if [ "$CI" = "true" ]; then
-    curl -s https://codecov.io/bash | bash -s -
-fi

--- a/scripts/integration
+++ b/scripts/integration
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+go test -v -tags=integration ./integration/...

--- a/scripts/verify
+++ b/scripts/verify
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+VERSION=$(git describe --abbrev=0 --tags)
+CHANGELOG_VERSION=$(perl -ne '/^\#\# (\d+(\.\d+)+) / && print "$$1\n"' CHANGELOG.md | head -n1)
+
+if [ "$VERSION" = "$CHANGELOG_VERSION" ]; then \
+  echo "version: $VERSION"; \
+else \
+  echo "Version number not found in CHANGELOG.md"; \
+  echo "version: $VERSION"; \
+  echo "CHANGELOG: $CHANGELOG_VERSION"; \
+  exit 1; \
+fi

--- a/test.env.encrypted
+++ b/test.env.encrypted
@@ -1,0 +1,2 @@
+codeship:v2
+D60517GB2KoD/FOGbzG33lblV399BXVw1oWdmfRc6nNkGjaqgfVV6t0nlMtTkx7kiOjBwndiy10odXcrWcI1D81599nddVrDvyXr+WJ70fil097f95McqcZed1bwrqteOe0=


### PR DESCRIPTION
## Summary

* Replace codecov with coveralls
* Move things from Makefile that are only run in CI to `scripts`

## Checklist

- [x] Added/updated tests?
- [x] Ran `make fmt`?
- [ ] CHANGELOG.md [Unreleased] section updated?
